### PR TITLE
Makes pactverification provider not mandatory

### DIFF
--- a/pact/consumer/core/src/main/java/org/arquillian/algeron/pact/consumer/core/AbstractConsumerPactTest.java
+++ b/pact/consumer/core/src/main/java/org/arquillian/algeron/pact/consumer/core/AbstractConsumerPactTest.java
@@ -111,7 +111,7 @@ public abstract class AbstractConsumerPactTest {
     }
 
     private boolean isClassAnnotatedWithPact(TestClass testClass) {
-        return testClass.getAnnotation(Pact.class) != null ? true : false;
+        return testClass.getAnnotation(Pact.class) != null;
     }
 
     protected Optional<PactMethod> findPactMethod(String currentProvider, TestClass testClass, PactVerification pactVerification) {

--- a/pact/consumer/core/src/main/java/org/arquillian/algeron/pact/consumer/core/AbstractConsumerPactTest.java
+++ b/pact/consumer/core/src/main/java/org/arquillian/algeron/pact/consumer/core/AbstractConsumerPactTest.java
@@ -92,18 +92,26 @@ public abstract class AbstractConsumerPactTest {
         }
     }
 
-    private String getProvider(TestClass testClass, PactVerification pactVerification) {
+    protected String getProvider(TestClass testClass, PactVerification pactVerification) {
         if (!"".equals(pactVerification.value().trim())) {
             return pactVerification.value();
         } else {
-            PactConsumerConfiguration pactConsumerConfiguration = pactConsumerConfigurationInstance.get();
-            if (pactConsumerConfiguration.isProviderSet()) {
-                return pactConsumerConfiguration.getProvider();
+            if (isClassAnnotatedWithPact(testClass)) {
+                return testClass.getAnnotation(Pact.class).provider();
             } else {
-                throw new IllegalArgumentException(
-                        String.format("Provider name must be set either by using provider configuration property in arquillian.xml or annotating %s test with %s with a provider set.", testClass.getName(), PactVerification.class.getName()));
+                PactConsumerConfiguration pactConsumerConfiguration = pactConsumerConfigurationInstance.get();
+                if (pactConsumerConfiguration.isProviderSet()) {
+                    return pactConsumerConfiguration.getProvider();
+                } else {
+                    throw new IllegalArgumentException(
+                            String.format("Provider name must be set either by using provider configuration property in arquillian.xml or annotating %s test with %s with a provider set.", testClass.getName(), PactVerification.class.getName()));
+                }
             }
         }
+    }
+
+    private boolean isClassAnnotatedWithPact(TestClass testClass) {
+        return testClass.getAnnotation(Pact.class) != null ? true : false;
     }
 
     protected Optional<PactMethod> findPactMethod(String currentProvider, TestClass testClass, PactVerification pactVerification) {

--- a/pact/consumer/core/src/test/java/org/arquillian/algeron/pact/consumer/core/ConsumerPactTestTest.java
+++ b/pact/consumer/core/src/test/java/org/arquillian/algeron/pact/consumer/core/ConsumerPactTestTest.java
@@ -25,6 +25,10 @@ public class ConsumerPactTestTest {
     @Mock
     PactVerification pactVerification;
 
+    @Mock
+    PactConsumerConfiguration pactConsumerConfiguration;
+
+
     @Before
     public void setup() {
         when(pactVerification.fragment()).thenReturn("");
@@ -73,8 +77,6 @@ public class ConsumerPactTestTest {
                 .isEqualTo(annotatedMethod);
         assertThat(pactFragmentMethod.get().getPact())
                 .isEqualTo(annotatedMethod.getAnnotation(Pact.class));
-
-
     }
 
     @Test
@@ -86,6 +88,45 @@ public class ConsumerPactTestTest {
 
         Assertions.assertThat(pactFragmentMethod).isNotPresent();
 
+    }
+
+    @Test
+    public void should_get_provider_name_from_pact_class_annotation() {
+        AbstractConsumerPactTest abstractConsumerPactTest = new StandaloneConsumerPactTest();
+        TestClass testClass = new TestClass(PactClassClassProvider.class);
+
+        when(pactVerification.value()).thenReturn("");
+
+        final String provider = abstractConsumerPactTest.getProvider(testClass,
+                pactVerification);
+        assertThat(provider).isEqualTo("p2");
+    }
+
+    @Test
+    public void should_get_provider_name_from_pact_provider_method_annotation() {
+        AbstractConsumerPactTest abstractConsumerPactTest = new StandaloneConsumerPactTest();
+        TestClass testClass = new TestClass(PactClassMethodProvider.class);
+
+        when(pactVerification.value()).thenReturn("p3");
+
+        final String provider = abstractConsumerPactTest.getProvider(testClass,
+                pactVerification);
+        assertThat(provider).isEqualTo("p3");
+    }
+
+    @Test
+    public void should_get_provider_name_from_configuration() {
+        AbstractConsumerPactTest abstractConsumerPactTest = new StandaloneConsumerPactTest();
+        TestClass testClass = new TestClass(PactMethodPactVerificationWithoutProvider.class);
+
+        when(pactVerification.value()).thenReturn("");
+        when(pactConsumerConfiguration.getProvider()).thenReturn("p4");
+        when(pactConsumerConfiguration.isProviderSet()).thenReturn(true);
+        abstractConsumerPactTest.pactConsumerConfigurationInstance = () -> pactConsumerConfiguration;
+
+        final String provider = abstractConsumerPactTest.getProvider(testClass,
+                pactVerification);
+        assertThat(provider).isEqualTo("p4");
     }
 
     public static class PactMethod {
@@ -110,6 +151,29 @@ public class ConsumerPactTestTest {
         public PactFragment contract3(PactDslWithProvider builder) {
             return null;
         }
+    }
+
+    @Pact(consumer = "c2", provider = "p2")
+    public static class PactClassClassProvider {
+        public PactFragment contract2(PactDslWithProvider builder) {
+            return null;
+        }
+    }
+
+    @Pact(consumer = "c2", provider = "p2")
+    public static class PactClassMethodProvider {
+        public PactFragment contract2(PactDslWithProvider builder) {
+            return null;
+        }
+    }
+
+    public static class PactMethodPactVerificationWithoutProvider {
+
+        @Pact(consumer = "c1", provider = "p1")
+        public PactFragment contract1(PactDslWithProvider builder) {
+            return null;
+        }
+
     }
 
 }

--- a/pact/consumer/spi/src/main/java/org/arquillian/algeron/pact/consumer/spi/PactVerification.java
+++ b/pact/consumer/spi/src/main/java/org/arquillian/algeron/pact/consumer/spi/PactVerification.java
@@ -18,7 +18,7 @@ public @interface PactVerification {
     /**
      * the tested provider name.
      */
-    String value();
+    String value() default "";
 
     /**
      * Method to call to get the pact fragment. Defaults to empty string which results in using the first one found.

--- a/pact/provider/ftest-container/src/test/java/org/arquillian/algeron/pact/provider/ftest/MyServiceProviderTest.java
+++ b/pact/provider/ftest-container/src/test/java/org/arquillian/algeron/pact/provider/ftest/MyServiceProviderTest.java
@@ -3,7 +3,6 @@ package org.arquillian.algeron.pact.provider.ftest;
 import org.arquillian.algeron.pact.provider.core.httptarget.Target;
 import org.arquillian.algeron.pact.provider.spi.Provider;
 import org.arquillian.algeron.pact.provider.spi.State;
-import org.arquillian.algeron.provider.core.retriever.ContractsFolder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;


### PR DESCRIPTION

#### Short description of what this resolves:

Makes pactverification provider not mandatory

#### Changes proposed in this pull request:

- get provider name from pact annotation if the annotation is at class level


**Fixes**: #58 
