### PR TITLE
Redirect Pact folder configuration to Gradle default output directory

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -206,7 +206,7 @@ public class ClientGatewayTest {
 <7> Defines which provider is validated when this test method is executed.
 <8> Asserts that the gateway can read the kind of messages sent by provider. Notice that now it is pretty simple, but in real test you'll test for example that message is correctly bound to an object.
 
-After this test is executed, contract is placed at `target/pacts` directory.
+After this test is executed, contract is placed at `target/pacts` directory or `build/pacts` in case of using Gradle.
 Then you can send contract to provider side.
 
 Notice that contract and/or mock responses are defined using Pact DSL.

--- a/pact/consumer/core/src/main/java/org/arquillian/algeron/pact/consumer/core/PactReportDirectoryConfigurator.java
+++ b/pact/consumer/core/src/main/java/org/arquillian/algeron/pact/consumer/core/PactReportDirectoryConfigurator.java
@@ -3,6 +3,9 @@ package org.arquillian.algeron.pact.consumer.core;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.core.api.event.ManagerStopping;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 public class PactReportDirectoryConfigurator {
 
     public static final String PACT_ROOT_DIR = "pact.rootDir";
@@ -16,6 +19,11 @@ public class PactReportDirectoryConfigurator {
                 System.setProperty(PACT_ROOT_DIR, pactConsumerConfiguration.getPactReportDir());
                 customReportDirectory = true;
             }
+        } else {
+            if (isGradle()) {
+                System.setProperty(PACT_ROOT_DIR, "build/pacts");
+                customReportDirectory = true;
+            }
         }
     }
 
@@ -23,6 +31,10 @@ public class PactReportDirectoryConfigurator {
         if (customReportDirectory) {
             System.clearProperty(PACT_ROOT_DIR);
         }
+    }
+
+    public boolean isGradle() {
+        return Files.exists(Paths.get("build.gradle"));
     }
 
 }


### PR DESCRIPTION
#### Short description of what this resolves:

By default pact contracts are generated to `target/pacts`. The problem is that in Gradle the default output directory is `build`. For this reason in case of running test in Gradle, the output will be `build/pacts`.

#### Changes proposed in this pull request:

- Detect if test is running on Gradle
- Change directory to Gradle output directory.
-


**Fixes**: #61
