### PR TITLE
feat(#75): Updates to Pact 3.5.0 final

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,9 +15,65 @@ image:https://travis-ci.org/arquillian/arquillian-algeron.svg?branch=master["Bui
 
 IMPORTANT: Using Arquillian Algeron Pact Provider requires at least Arquillian Core 1.1.12.Final or above.
 
+
+IMPORTANT: Arquillian Algeron Pact 1.X works with versions of Pact previous to 3.5.0. Arquillian Algeron Pact 2.X works with Pact 3.5.0.
+
 ifndef::generated-doc[]
 To read complete documentation visit http://arquillian.org/arquillian-algeron/
 endif::generated-doc[]
+
+== Migration from Arquillan Algeron Pact 1.X to 2.X
+
+With the release of Pact 3.5.0, `toFragment` method has been deprecated in favor of `toPact()`.
+Also this method instead of returning `PactFragment` now returns `RequestResponsePact`.
+
+Because of this change your contract definition should be adapted accordantly:
+
+[source, java]
+.Algeron Pact 1.X
+----
+@Pact(provider = "test_provider", consumer = "test_consumer")
+public PactFragment createFragment(PactDslWithProvider builder) {
+
+    Map<String, String> header = new HashMap<>();
+    header.put("Content-Type", "application/json");
+
+    return builder
+        .given("test state")
+        .uponReceiving("ConsumerTest test interaction")
+        .path("/")
+        .method("GET")
+        .willRespondWith()
+        .status(200)
+        .headers(header)
+        .bodyWithSingleQuotes(("{'responsetest': true, 'name': 'harry'}"))
+        .toFragment();
+}
+----
+
+to:
+
+[source, java]
+.Algeron Pact 2.X
+----
+@Pact(provider = "test_provider", consumer = "test_consumer")
+public RequestResponsePact createFragment(PactDslWithProvider builder) {
+
+    Map<String, String> header = new HashMap<>();
+    header.put("Content-Type", "application/json");
+
+    return builder
+        .given("test state")
+        .uponReceiving("ConsumerTest test interaction")
+        .path("/")
+        .method("GET")
+        .willRespondWith()
+        .status(200)
+        .headers(header)
+        .bodyWithSingleQuotes(("{'responsetest': true, 'name': 'harry'}"))
+        .toPact();
+}
+----
 
 == What is Arquillian Algeron?
 

--- a/docs/consumer.adoc
+++ b/docs/consumer.adoc
@@ -3,6 +3,8 @@
 First thing to do is develop the *Consumer* part of the test.
 Consumer part of Consumer-Driven Contract defines requirements from the consumer of the API which are then used to develop the client interaction with the API as well as to validate provider implementation.
 
+IMPORTANT: Arquillian Algeron Pact 1.X works with versions of Pact previous to 3.5.0. Arquillian Algeron Pact 2.X works with Pact 3.5.0.
+
 == Pact Consumer Enrichers
 
 You can use in a test `@StubServer` annotation to inject URL where stub http server is started.
@@ -75,11 +77,11 @@ Then you need to add `arquillian-pact-consumer` dependency as well as `pact-jvm-
         <groupId>au.com.dius</groupId>
         <artifactId>pact-jvm-consumer_2.11</artifactId>
         <scope>test</scope>
-        <version>3.5.0-beta.2</version> <!--1-->
+        <version>3.5.0</version> <!--1-->
     </dependency>
 </dependencies>
 ----
-<1> Arquillian Algeron Pact has been tested with latest version, but it should work with any 3.X version.
+<1> Arquillian Algeron Pact 2.X only works with 3.5.0, Arquillian Algeron Pact 1.X works with < 3.5.0.
 
 After dependencies you can write the test that defines the contract:
 
@@ -97,7 +99,7 @@ public class ClientGatewayTest {
         return ShrinkWrap.create(JavaArchive.class).addClasses(ClientGateway.class);
     }
 
-    public PactFragment createFragment(PactDslWithProvider builder) {
+    public RequestResponsePact createFragment(PactDslWithProvider builder) {
 
         Map<String, String> header = new HashMap<>();
         header.put("Content-Type", "application/json");
@@ -111,7 +113,7 @@ public class ClientGatewayTest {
                 .status(200)
                 .headers(header)
                 .body("{\"responsetest\": true, \"name\": \"harry\"}")
-                .toFragment(); // <4>
+                .toPact(); // <4>
     }
 
     @Inject // <5>
@@ -166,7 +168,7 @@ Obviously no `@Deployment` method is required:
 public class ConsumerTest {
 
     @Pact(provider = "test_provider", consumer = "test_consumer")
-    public PactFragment createFragment(PactDslWithProvider builder) {
+    public RequestResponsePact createFragment(PactDslWithProvider builder) {
 
         Map<String, String> header = new HashMap<>();
         header.put("Content-Type", "application/json");
@@ -180,7 +182,7 @@ public class ConsumerTest {
                 .status(200)
                 .headers(header)
                 .body("{\"responsetest\": true, \"name\": \"harry\"}")
-                .toFragment();
+                .toPact();
     }
 
     @StubServer

--- a/pact/consumer/core/src/main/java/org/arquillian/algeron/pact/consumer/core/PactMismatchesException.java
+++ b/pact/consumer/core/src/main/java/org/arquillian/algeron/pact/consumer/core/PactMismatchesException.java
@@ -1,0 +1,12 @@
+package org.arquillian.algeron.pact.consumer.core;
+
+import au.com.dius.pact.consumer.PactVerificationResult;
+
+public class PactMismatchesException extends AssertionError {
+    private final PactVerificationResult mismatches;
+
+    public PactMismatchesException(PactVerificationResult mismatches) {
+        super(mismatches.getDescription());
+        this.mismatches = mismatches;
+    }
+}

--- a/pact/consumer/core/src/main/java/org/arquillian/algeron/pact/consumer/core/client/PactConsumerArchiveAppender.java
+++ b/pact/consumer/core/src/main/java/org/arquillian/algeron/pact/consumer/core/client/PactConsumerArchiveAppender.java
@@ -1,16 +1,26 @@
 package org.arquillian.algeron.pact.consumer.core.client;
 
+import au.com.dius.pact.consumer.ConsumerPactRunnerKt;
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpsServer;
+import com.sun.net.httpserver.spi.HttpServerProvider;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Properties;
 import org.arquillian.algeron.consumer.StubServer;
+import org.arquillian.algeron.pact.consumer.core.AbstractConsumerPactTest;
+import org.arquillian.algeron.pact.consumer.core.PactConsumerConfiguration;
 import org.arquillian.algeron.pact.consumer.core.PactFilesCommand;
+import org.arquillian.algeron.pact.consumer.core.PactMismatchesException;
 import org.arquillian.algeron.pact.consumer.core.client.container.ConsumerProviderPair;
+import org.arquillian.algeron.pact.consumer.core.client.container.PactConsumerConfigurator;
 import org.arquillian.algeron.pact.consumer.core.client.container.PactConsumerRemoteExtension;
+import org.arquillian.algeron.pact.consumer.core.client.container.RemoteConsumerPactTest;
 import org.arquillian.algeron.pact.consumer.core.client.enricher.StubServerEnricher;
 import org.arquillian.algeron.pact.consumer.core.util.PactConsumerVersionExtractor;
 import org.arquillian.algeron.pact.consumer.core.util.ResolveClassAnnotation;
-import org.arquillian.algeron.pact.consumer.core.AbstractConsumerPactTest;
-import org.arquillian.algeron.pact.consumer.core.PactConsumerConfiguration;
-import org.arquillian.algeron.pact.consumer.core.client.container.PactConsumerConfigurator;
-import org.arquillian.algeron.pact.consumer.core.client.container.RemoteConsumerPactTest;
 import org.arquillian.algeron.pact.consumer.spi.Pact;
 import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
@@ -22,10 +32,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.Properties;
-
 public class PactConsumerArchiveAppender implements AuxiliaryArchiveAppender {
 
     @Inject
@@ -33,15 +39,21 @@ public class PactConsumerArchiveAppender implements AuxiliaryArchiveAppender {
 
     @Override
     public Archive<?> createAuxiliaryArchive() {
-        final JavaArchive arquillianPactConsumer = ShrinkWrap.create(JavaArchive.class, "arquillian-pact-consumer.jar")
+        JavaArchive arquillianPactConsumer = null;
+        arquillianPactConsumer = ShrinkWrap.create(JavaArchive.class, "arquillian-pact-consumer.jar")
             // Add Core classes required in container part
             .addClasses(AbstractConsumerPactTest.class,
                 RemoteConsumerPactTest.class, PactConsumerConfiguration.class,
                 MockProviderConfigCreator.class, PactConsumerConfigurator.class,
                 PactConsumerRemoteExtension.class, PactFilesCommand.class, ConsumerProviderPair.class,
-                ResolveClassAnnotation.class, StubServer.class, StubServerEnricher.class)
+                PactMismatchesException.class, ConsumerPactRunnerKt.class, HttpHandler.class, HttpServer.class,
+                HttpServerProvider.class,
+                ResolveClassAnnotation.class, StubServer.class, StubServerEnricher.class,
+                HttpsServer.class, HttpContext.class)
             .addPackages(true, Pact.class.getPackage())
             .addAsServiceProvider(RemoteLoadableExtension.class, PactConsumerRemoteExtension.class);
+
+        arquillianPactConsumer = addSunHttpServer(arquillianPactConsumer);
 
         final Properties properties = pactConsumerConfigurationInstance.get().asProperties();
         String configuration = toString(properties);
@@ -54,6 +66,61 @@ public class PactConsumerArchiveAppender implements AuxiliaryArchiveAppender {
 
         final JavaArchive merge = merge(arquillianPactConsumer, pactConsumerDeps);
         return merge;
+    }
+
+    private JavaArchive addSunHttpServer(JavaArchive arquillianPactConsumer) {
+        try {
+            arquillianPactConsumer.addClass(Class.forName("com.sun.net.httpserver.spi.HttpServerProvider$1"))
+                .addClass(Class.forName("sun.net.httpserver.DefaultHttpServerProvider"))
+                .addClass(Class.forName("sun.net.httpserver.HttpsServerImpl"))
+                .addClass(Class.forName("sun.net.httpserver.HttpServerImpl"))
+                .addClass(Class.forName("sun.net.httpserver.HttpContextImpl"))
+                .addClass(Class.forName("sun.net.httpserver.ServerImpl"))
+                .addClass(Class.forName("sun.net.httpserver.TimeSource"))
+                .addClass(Class.forName("sun.net.httpserver.ServerImpl$ServerTimerTask"))
+                .addClass(Class.forName("sun.net.httpserver.ServerImpl$ServerTimerTask1"))
+                .addClass(Class.forName("sun.net.httpserver.ServerConfig"))
+                .addClass(Class.forName("sun.net.httpserver.ServerConfig$1"))
+                .addClass(Class.forName("sun.net.httpserver.ServerConfig$2"))
+                .addClass(Class.forName("sun.net.httpserver.ContextList"))
+                .addClass(Class.forName("sun.net.httpserver.ServerImpl$Dispatcher"))
+                .addClass(Class.forName("sun.net.httpserver.HttpError"))
+                .addClass(Class.forName("sun.net.httpserver.AuthFilter"))
+                .addClass(Class.forName("com.sun.net.httpserver.Filter"))
+                .addClass(Class.forName("sun.net.httpserver.ServerImpl$DefaultExecutor"))
+                .addClass(Class.forName("sun.net.httpserver.HttpConnection"))
+                .addClass(Class.forName("sun.net.httpserver.HttpConnection$State"))
+                .addClass(Class.forName("sun.net.httpserver.ServerImpl$Exchange"))
+                .addClass(Class.forName("sun.net.httpserver.SSLStreams$InputStream"))
+                .addClass(Class.forName("sun.net.httpserver.SSLStreams$OutputStream"))
+                .addClass(Class.forName("sun.net.httpserver.Request$ReadStream"))
+                .addClass(Class.forName("sun.net.httpserver.Request$WriteStream"))
+                .addClass(Class.forName("com.sun.net.httpserver.HttpExchange"))
+                .addClass(Class.forName("sun.net.httpserver.HttpsExchangeImpl"))
+                .addClass(Class.forName("com.sun.net.httpserver.HttpsExchange"))
+                .addClass(Class.forName("sun.net.httpserver.HttpExchangeImpl"))
+                .addClass(Class.forName("sun.net.httpserver.Request"))
+                .addClass(Class.forName("com.sun.net.httpserver.Headers"))
+                .addClass(Class.forName("sun.net.httpserver.ExchangeImpl"))
+                .addClass(Class.forName("sun.net.httpserver.ExchangeImpl$1"))
+                .addClass(Class.forName("sun.net.httpserver.UnmodifiableHeaders"))
+                .addClass(Class.forName("sun.net.httpserver.UndefLengthOutputStream"))
+                .addClass(Class.forName("sun.net.httpserver.LeftOverInputStream"))
+                .addClass(Class.forName("sun.net.httpserver.ChunkedOutputStream"))
+                .addClass(Class.forName("sun.net.httpserver.FixedLengthOutputStream"))
+                .addClass(Class.forName("sun.net.httpserver.Event"))
+                .addClass(Class.forName("sun.net.httpserver.WriteFinishedEvent"))
+                .addClass(Class.forName("sun.net.httpserver.PlaceholderOutputStream"))
+                .addClass(Class.forName("sun.net.httpserver.ChunkedInputStream"))
+                .addClass(Class.forName("sun.net.httpserver.FixedLengthInputStream"))
+                .addClass(Class.forName("com.sun.net.httpserver.Filter$Chain"))
+                .addClass(Class.forName("sun.net.httpserver.ServerImpl$Exchange$LinkHandler"))
+                .addClass(Class.forName("sun.net.httpserver.Code"))
+                .addClass(Class.forName("sun.net.httpserver.StreamClosedException"));
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+        return arquillianPactConsumer;
     }
 
     private String toString(Properties properties) {

--- a/pact/consumer/core/src/test/java/org/arquillian/algeron/pact/consumer/core/ConsumerPactTestTest.java
+++ b/pact/consumer/core/src/test/java/org/arquillian/algeron/pact/consumer/core/ConsumerPactTestTest.java
@@ -1,7 +1,7 @@
 package org.arquillian.algeron.pact.consumer.core;
 
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
-import au.com.dius.pact.model.PactFragment;
+import au.com.dius.pact.model.RequestResponsePact;
 import org.arquillian.algeron.pact.consumer.core.client.StandaloneConsumerPactTest;
 import org.arquillian.algeron.pact.consumer.spi.Pact;
 import org.arquillian.algeron.pact.consumer.spi.PactVerification;
@@ -132,14 +132,14 @@ public class ConsumerPactTestTest {
     public static class PactMethod {
 
         @Pact(consumer = "c1", provider = "p1")
-        public PactFragment contract1(PactDslWithProvider builder) {
+        public RequestResponsePact contract1(PactDslWithProvider builder) {
             return null;
         }
     }
 
     @Pact(consumer = "c2", provider = "p2")
     public static class PactClass {
-        public PactFragment contract2(PactDslWithProvider builder) {
+        public RequestResponsePact contract2(PactDslWithProvider builder) {
             return null;
         }
     }
@@ -147,21 +147,21 @@ public class ConsumerPactTestTest {
     @Pact(consumer = "c3", provider = "p3")
     public static class PactMethodClass {
         @Pact(consumer = "c4", provider = "p4")
-        public PactFragment contract3(PactDslWithProvider builder) {
+        public RequestResponsePact contract3(PactDslWithProvider builder) {
             return null;
         }
     }
 
     @Pact(consumer = "c2", provider = "p2")
     public static class PactClassClassProvider {
-        public PactFragment contract2(PactDslWithProvider builder) {
+        public RequestResponsePact contract2(PactDslWithProvider builder) {
             return null;
         }
     }
 
     @Pact(consumer = "c2", provider = "p2")
     public static class PactClassMethodProvider {
-        public PactFragment contract2(PactDslWithProvider builder) {
+        public RequestResponsePact contract2(PactDslWithProvider builder) {
             return null;
         }
     }
@@ -169,7 +169,7 @@ public class ConsumerPactTestTest {
     public static class PactMethodPactVerificationWithoutProvider {
 
         @Pact(consumer = "c1", provider = "p1")
-        public PactFragment contract1(PactDslWithProvider builder) {
+        public RequestResponsePact contract1(PactDslWithProvider builder) {
             return null;
         }
     }

--- a/pact/consumer/ftest-container/src/test/java/ClientGatewayTest.java
+++ b/pact/consumer/ftest-container/src/test/java/ClientGatewayTest.java
@@ -1,5 +1,6 @@
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
 import au.com.dius.pact.model.PactFragment;
+import au.com.dius.pact.model.RequestResponsePact;
 import org.arquillian.algeron.consumer.StubServer;
 import org.arquillian.algeron.pact.consumer.ftest.ClientGateway;
 import org.arquillian.algeron.pact.consumer.spi.Pact;
@@ -29,7 +30,7 @@ public class ClientGatewayTest {
         return ShrinkWrap.create(JavaArchive.class).addClasses(ClientGateway.class);
     }
 
-    public PactFragment createFragment(PactDslWithProvider builder) {
+    public RequestResponsePact createFragment(PactDslWithProvider builder) {
 
         Map<String, String> header = new HashMap<>();
         header.put("Content-Type", "application/json");
@@ -43,7 +44,7 @@ public class ClientGatewayTest {
             .status(200)
             .headers(header)
             .bodyWithSingleQuotes("{'responsetest': true, 'name': 'harry'}")
-            .toFragment();
+            .toPact();
     }
 
     @EJB
@@ -55,6 +56,6 @@ public class ClientGatewayTest {
     @Test
     @PactVerification("test_provider")
     public void should_return_message() throws IOException {
-        assertThat(clientGateway.getMessage(url), is("{\"responsetest\": true, \"name\": \"harry\"}"));
+        assertThat(clientGateway.getMessage(url), is("{\"responsetest\":true,\"name\":\"harry\"}"));
     }
 }

--- a/pact/consumer/ftest-container/src/test/resources/arquillian.xml
+++ b/pact/consumer/ftest-container/src/test/resources/arquillian.xml
@@ -6,7 +6,7 @@
 
   <container qualifier="chameleon" default="true">
     <configuration>
-      <property name="chameleonTarget">wildfly:9.0.0.Final:managed</property>
+      <property name="chameleonTarget">wildfly:10.0.0.Final:managed</property>
       <!--payara:4.1.1.163:managed-->
     </configuration>
   </container>

--- a/pact/consumer/ftest/src/test/java/org/arquillian/algeron/pact/consumer/ftest/ConsumerTest.java
+++ b/pact/consumer/ftest/src/test/java/org/arquillian/algeron/pact/consumer/ftest/ConsumerTest.java
@@ -2,6 +2,7 @@ package org.arquillian.algeron.pact.consumer.ftest;
 
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
 import au.com.dius.pact.model.PactFragment;
+import au.com.dius.pact.model.RequestResponsePact;
 import org.arquillian.algeron.consumer.StubServer;
 import org.arquillian.algeron.pact.consumer.spi.Pact;
 import org.arquillian.algeron.pact.consumer.spi.PactVerification;
@@ -22,7 +23,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 public class ConsumerTest {
 
     @Pact(provider = "test_provider", consumer = "test_consumer")
-    public PactFragment createFragment(PactDslWithProvider builder) {
+    public RequestResponsePact createFragment(PactDslWithProvider builder) {
 
         Map<String, String> header = new HashMap<>();
         header.put("Content-Type", "application/json");
@@ -36,7 +37,7 @@ public class ConsumerTest {
             .status(200)
             .headers(header)
             .bodyWithSingleQuotes(("{'responsetest': true, 'name': 'harry'}"))
-            .toFragment();
+            .toPact();
     }
 
     @StubServer

--- a/pact/provider/core/src/test/java/org/arquillian/algeron/pact/provider/core/InteractionRunnerTest.java
+++ b/pact/provider/core/src/test/java/org/arquillian/algeron/pact/provider/core/InteractionRunnerTest.java
@@ -45,9 +45,6 @@ public class InteractionRunnerTest {
     private RequestResponseInteraction requestResponseInteraction;
 
     @Mock
-    private ProviderState providerState;
-
-    @Mock
     private Instance algeronConfiguration;
 
     private Instance<Pacts> pactsInstance;
@@ -98,7 +95,8 @@ public class InteractionRunnerTest {
     @org.junit.Test
     public void should_execute_states_with_regular_expression_syntax_for_simple_types() {
 
-        when(providerState.getName()).thenReturn("I have 36 cukes in my belly");
+        ProviderState providerState = new ProviderState("I have 36 cukes in my belly");
+
         final List<ProviderState> providerStates = new ArrayList<>();
         providerStates.add(providerState);
         when(requestResponseInteraction.getProviderStates()).thenReturn(providerStates);
@@ -116,7 +114,8 @@ public class InteractionRunnerTest {
     @org.junit.Test
     public void should_execute_states_with_regular_expression_syntax_for_collection_types() {
 
-        when(providerState.getName()).thenReturn("The following animals: cow, pig, bug");
+        ProviderState providerState = new ProviderState("The following animals: cow, pig, bug");
+
         final List<ProviderState> providerStates = new ArrayList<>();
         providerStates.add(providerState);
         when(requestResponseInteraction.getProviderStates()).thenReturn(providerStates);

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <version.mockito>1.10.19</version.mockito>
     <version.assertj>3.6.2</version.assertj>
     <version.shrinkwrap.resolvers>2.2.6</version.shrinkwrap.resolvers>
-    <version.pact>3.5.0-rc.2</version.pact>
+    <version.pact>3.5.0</version.pact>
     <!-- Requirement from pact to run-->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
#### Short description of what this resolves:

Updates to Pact 3.5.0 final

#### Changes proposed in this pull request:

- Now user needs to use `toPact` instead of `toFragment` and the return type is not `PactFragment` but `RequestResponsePact`


**Fixes**: #75 
