### PR TITLE
fix(#84): Updates Pact-Jvm version to 3.5.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
   <properties>
     <version.arquillian_core>1.1.15.Final</version.arquillian_core>
-    <version.pact>3.5.8</version.pact>
+    <version.pact>3.5.10</version.pact>
 
     <!-- Requirement from pact to run-->
     <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
#### Short description of what this resolves:

Updates Pact-JVM  to 3.5.10

#### Changes proposed in this pull request:

- Update Dependency
- Adapts to new method signature
- Workaround one bug found in how Pact-Jvm treat HTTP paths (PR sent to Pact-JVM providing a fix https://github.com/DiUS/pact-jvm/pull/607


**Fixes**: #84
