### PR TITLE
fix pacts loading from broker

### DIFF
--- a/pact/provider/core/src/main/java/org/arquillian/algeron/pact/provider/core/PactsRetriever.java
+++ b/pact/provider/core/src/main/java/org/arquillian/algeron/pact/provider/core/PactsRetriever.java
@@ -69,7 +69,7 @@ public class PactsRetriever {
             final List<URI> contractsDirectory = contractsSource.retrieve();
 
             Map<String, Object> options = new HashMap<>();
-            if ( algeronProviderConfigurationInstance.get() != null) {
+            if (algeronProviderConfigurationInstance.get() != null && algeronProviderConfigurationInstance.get().getRetrieverConfiguration() != null) {
                 Map<String, Object> config = algeronProviderConfigurationInstance.get().getRetrieverConfiguration();
                 // if pact retrieve specifies username, we need to create Pact options with authentication flag
                 if (config.containsKey("username")) {
@@ -105,7 +105,7 @@ public class PactsRetriever {
     }
 
     protected ContractsRetriever getContractsSource(final TestClass testClass,
-        AlgeronProviderConfiguration algeronProviderConfiguration) {
+                                                    AlgeronProviderConfiguration algeronProviderConfiguration) {
 
         // Gets a test annotated directly with PactSource annotation
         final ContractsSource pactSource = testClass.getAnnotation(ContractsSource.class);

--- a/pact/provider/core/src/main/java/org/arquillian/algeron/pact/provider/core/PactsRetriever.java
+++ b/pact/provider/core/src/main/java/org/arquillian/algeron/pact/provider/core/PactsRetriever.java
@@ -69,12 +69,13 @@ public class PactsRetriever {
             final List<URI> contractsDirectory = contractsSource.retrieve();
 
             Map<String, Object> options = new HashMap<>();
-            Map<String, Object> config = algeronProviderConfigurationInstance.get().getRetrieverConfiguration();
-            // if pact retrieve specifies username, we need to create Pact options with authentication flag
-            if (config.containsKey("username")) {
-                options.put("authentication", Arrays.asList("Basic",  config.get("username"), config.get("password")));
+            if ( algeronProviderConfigurationInstance.get() != null) {
+                Map<String, Object> config = algeronProviderConfigurationInstance.get().getRetrieverConfiguration();
+                // if pact retrieve specifies username, we need to create Pact options with authentication flag
+                if (config.containsKey("username")) {
+                    options.put("authentication", Arrays.asList("Basic", config.get("username"), config.get("password")));
+                }
             }
-
             pacts = loadContractFiles(contractsDirectory, serviceName, options).stream()
                 .filter(p -> consumerName == null || p.getConsumer().getName().equals(consumerName))
                 .collect(toList());

--- a/pact/provider/spi/src/main/java/org/arquillian/algeron/pact/provider/spi/Consumer.java
+++ b/pact/provider/spi/src/main/java/org/arquillian/algeron/pact/provider/spi/Consumer.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
  * Annotation to set consumer in test
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})
 public @interface Consumer {
     /**
      * @return consumer name for pact test running


### PR DESCRIPTION
#### Short description of what this resolves:
Resolves #129 by propagating the basic auth config to PactReader

#### Changes proposed in this pull request:

- Update target of `@Consumer` annotation, so that it can be applied on class (and subsequently used in the loading of pacts to filter out contracts only for consumer)
- propagate the basic auth config attributes to PactReader in for of Pact options with `authentication` option. 

Fixes #129
